### PR TITLE
Fix Windows container PPL build: ensure Docker engine is ready (runner-images #13729)

### DIFF
--- a/.github/workflows/build-lvlibp-windows-container.yml
+++ b/.github/workflows/build-lvlibp-windows-container.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '2026q1'
         type: string
+      simulate_docker_stopped:
+        description: 'Deterministic repro: stop the Docker service before the build to emulate runner-images #13729'
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       labview_version:
@@ -135,6 +140,25 @@ jobs:
               ('- Resolved: `{0}.{1}.{2}.{3}`' -f $major, $minor, $patch, $build)
             ) -join [Environment]::NewLine | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           }
+
+      - name: Simulate Docker stopped (deterministic repro)
+        if: ${{ inputs.simulate_docker_stopped == true }}
+        shell: powershell
+        run: |
+          Write-Host 'Repro: stopping Docker services to emulate runner-images #13729 (Docker service Stopped on boot)...'
+          Get-Service -Name '*docker*' -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host ("Stopping '{0}' (status {1})" -f $_.Name, $_.Status)
+            try { Stop-Service -Name $_.Name -Force -ErrorAction Stop } catch { Write-Warning $_.Exception.Message }
+          }
+          & docker info *> $null
+          Write-Host ("docker info exit (expected non-zero while stopped): {0}" -f $LASTEXITCODE)
+          exit 0
+
+      - name: Ensure Docker engine is ready (Windows)
+        shell: powershell
+        run: |
+          .\Tooling\Wait-ForDockerWindows.ps1 -TimeoutSeconds 120 -PollIntervalSeconds 3
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build PPL with Windows Docker
         uses: ni/open-source/build-spec-docker-windows@actions

--- a/.github/workflows/build-lvlibp-windows-container.yml
+++ b/.github/workflows/build-lvlibp-windows-container.yml
@@ -145,13 +145,16 @@ jobs:
         if: ${{ inputs.simulate_docker_stopped == true }}
         shell: powershell
         run: |
+          $ErrorActionPreference = 'Continue'
           Write-Host 'Repro: stopping Docker services to emulate runner-images #13729 (Docker service Stopped on boot)...'
           Get-Service -Name '*docker*' -ErrorAction SilentlyContinue | ForEach-Object {
             Write-Host ("Stopping '{0}' (status {1})" -f $_.Name, $_.Status)
             try { Stop-Service -Name $_.Name -Force -ErrorAction Stop } catch { Write-Warning $_.Exception.Message }
           }
-          & docker info *> $null
-          Write-Host ("docker info exit (expected non-zero while stopped): {0}" -f $LASTEXITCODE)
+          # Capture (do not fail on) the expected npipe error to document the repro.
+          try { $probe = (& docker info 2>&1 | Out-String) } catch { $probe = $_.Exception.Message }
+          Write-Host ("docker info while stopped (expected npipe failure):`n{0}" -f $probe)
+          Write-Host 'Docker stopped; the next step should restart it and recover.'
           exit 0
 
       - name: Ensure Docker engine is ready (Windows)

--- a/Tooling/Wait-ForDockerWindows.ps1
+++ b/Tooling/Wait-ForDockerWindows.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+    Ensures the Docker engine is running on a Windows runner before container
+    operations. Runs under Windows PowerShell 5.1 (shell: powershell).
+
+.DESCRIPTION
+    Works around the GitHub Actions windows-2022/windows-2025 runner regression
+    (actions/runner-images #13729) where, after the Docker Engine v29 rollout,
+    the Docker service intermittently boots in a Stopped state because of a
+    Hyper-V virtual switch creation race. Symptom:
+
+        failed to connect to the docker API at npipe:////./pipe/docker_engine;
+        ... open //./pipe/docker_engine: The system cannot find the file
+        specified.
+
+    The script probes readiness with `docker info` (not Test-Path on the named
+    pipe), starts any *docker* services that are not running, and polls until
+    the engine responds or the timeout elapses. It deliberately avoids any
+    PowerShell 7-only syntax so it can run on the Windows PowerShell that ships
+    with the runner image.
+
+.PARAMETER TimeoutSeconds
+    Maximum time to wait for the Docker engine to become ready. Default 120.
+
+.PARAMETER PollIntervalSeconds
+    Delay between readiness probes. Default 3.
+
+.EXAMPLE
+    powershell -NoProfile -File Tooling/Wait-ForDockerWindows.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 3600)]
+    [int]$TimeoutSeconds = 120,
+
+    [ValidateRange(1, 60)]
+    [int]$PollIntervalSeconds = 3
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Test-DockerReady {
+    & docker info *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Start-DockerService {
+    $services = Get-Service -Name '*docker*' -ErrorAction SilentlyContinue
+    if (-not $services) {
+        Write-Host 'No Docker-related Windows services were found.'
+        return
+    }
+
+    foreach ($service in $services) {
+        Write-Host ("Docker service '{0}' status: {1}" -f $service.Name, $service.Status)
+        if ($service.Status -ne 'Running') {
+            try {
+                Write-Host ("Starting Docker service '{0}'..." -f $service.Name)
+                Start-Service -Name $service.Name
+            } catch {
+                Write-Warning ("Failed to start service '{0}': {1}" -f $service.Name, $_.Exception.Message)
+            }
+        }
+    }
+}
+
+function Write-DockerDiagnostic {
+    Write-Host '--- Docker service status ---'
+    Get-Service -Name '*docker*' -ErrorAction SilentlyContinue |
+        Format-Table -AutoSize -Property Name, Status, StartType |
+        Out-String | Write-Host
+
+    Write-Host '--- docker version ---'
+    & docker version
+
+    try {
+        Write-Host '--- Recent System event log (docker / hyper-v / hns / vmcompute) ---'
+        $events = Get-WinEvent -FilterHashtable @{ LogName = 'System'; StartTime = (Get-Date).AddMinutes(-15) } -ErrorAction SilentlyContinue |
+            Where-Object { $_.ProviderName -match 'docker|hyper-v|hns|vmcompute' } |
+            Select-Object -First 20 -Property TimeCreated, ProviderName, Id, LevelDisplayName, Message
+        if ($events) {
+            $events | Format-List | Out-String | Write-Host
+        } else {
+            Write-Host 'No matching recent events.'
+        }
+    } catch {
+        Write-Warning ("Could not read event logs: {0}" -f $_.Exception.Message)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if (-not (Get-Command -Name docker -ErrorAction SilentlyContinue)) {
+    Write-Error 'Docker CLI not found on PATH.' -ErrorAction Continue
+    exit 1
+}
+
+Write-Host '============================================================'
+Write-Host ' Ensuring Docker engine is ready (Windows)'
+Write-Host (' Timeout: {0}s  Poll: {1}s' -f $TimeoutSeconds, $PollIntervalSeconds)
+Write-Host '============================================================'
+
+if (Test-DockerReady) {
+    Write-Host 'Docker engine is already responding.'
+    exit 0
+}
+
+Write-Host 'Docker engine not responding yet; attempting to start services...'
+Start-DockerService
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$attempt = 0
+while ((Get-Date) -lt $deadline) {
+    $attempt++
+    if (Test-DockerReady) {
+        Write-Host ("Docker engine became ready after {0} attempt(s)." -f $attempt)
+        exit 0
+    }
+    Write-Host ("Docker not ready (attempt {0}); retrying in {1}s..." -f $attempt, $PollIntervalSeconds)
+    Start-Sleep -Seconds $PollIntervalSeconds
+}
+
+Write-DockerDiagnostic
+Write-Error ("Docker engine did not become ready within {0} seconds." -f $TimeoutSeconds) -ErrorAction Continue
+exit 1

--- a/Tooling/Wait-ForDockerWindows.ps1
+++ b/Tooling/Wait-ForDockerWindows.ps1
@@ -44,9 +44,26 @@ $ErrorActionPreference = 'Stop'
 # Helpers
 # ---------------------------------------------------------------------------
 
+function Invoke-DockerSafely {
+    # Runs the docker CLI without letting native stderr (e.g. the npipe error
+    # emitted while the daemon is down) raise a terminating NativeCommandError
+    # under $ErrorActionPreference = 'Stop'. Returns the exit code and output.
+    param([Parameter(Mandatory = $true)][string[]]$DockerArgs)
+
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & docker @DockerArgs 2>&1 | Out-String
+        return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
+    } catch {
+        return [pscustomobject]@{ ExitCode = 1; Output = $_.Exception.Message }
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
 function Test-DockerReady {
-    & docker info *> $null
-    return ($LASTEXITCODE -eq 0)
+    return ((Invoke-DockerSafely -DockerArgs @('info')).ExitCode -eq 0)
 }
 
 function Start-DockerService {
@@ -76,7 +93,7 @@ function Write-DockerDiagnostic {
         Out-String | Write-Host
 
     Write-Host '--- docker version ---'
-    & docker version
+    Write-Host (Invoke-DockerSafely -DockerArgs @('version')).Output
 
     try {
         Write-Host '--- Recent System event log (docker / hyper-v / hns / vmcompute) ---'


### PR DESCRIPTION
## Summary
The Windows container PPL build (`build-lvlibp-windows-container.yml`) fails while the Linux build succeeds — the CI parity gap. Root cause is an upstream GitHub runner regression, not the LabVIEW project or the build spec.

## Root cause
After the Docker Engine v29 rollout to Windows runners (`actions/runner-images` #13474), the `windows-2022` image intermittently boots with the **Docker service `Stopped`** due to a Hyper-V virtual-switch creation race (`actions/runner-images` #13729, Microsoft-acknowledged, no ETA). The external `ni/open-source/build-spec-docker-windows` action runs `docker pull` first, which then fails instantly with `npipe:////./pipe/docker_engine ... The system cannot find the file specified`, producing a ~21s job failure. `ubuntu-latest` is unaffected, hence Linux passes and Windows fails.

## Fix
- New `Tooling/Wait-ForDockerWindows.ps1` (Windows PowerShell 5.1 compatible): probes `docker info`, starts any `*docker*` service that is not running, and polls until ready (120s default), dumping service status and recent System event-log entries on timeout.
- New workflow step **Ensure Docker engine is ready (Windows)** (`shell: powershell`) runs the helper before the build.

## Deterministic repro
Added an opt-in `workflow_dispatch` input `simulate_docker_stopped`. When `true`, a gated step stops the Docker service before the readiness step, deterministically reproducing #13729 and proving the fix recovers the run.

## Validation
- Helper parses and runs under Windows PowerShell 5.1; happy-path exit 0.
- PSScriptAnalyzer (repo settings): 0 findings.
- Recommended: re-run the Windows job with `simulate_docker_stopped = true` to confirm recovery.

## Scope
Infra workaround only — no LabVIEW code or build-spec changes. Switching to `windows-2025` is not reliable (#13729 affects it too).
